### PR TITLE
Update to new LibCD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .gradle/
 build/
 out/
+classes/
 
 # idea
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 	maven { url = "https://maven.fabricmc.net/" }
 	maven { url = "https://minecraft.curseforge.com/api/maven" }
 	maven { url = 'http://maven.sargunv.s3-website-us-west-2.amazonaws.com/' }
-	maven { url 'https://jitpack.io' }
+	maven { url = 'http://server.bbkr.space:8081/artifactory/libs-release' }
 }
 
 
@@ -26,8 +26,8 @@ dependencies {
 	modCompile "net.fabricmc.fabric-api:fabric-api:0.3.0+build.187"
 
 	// LibCD for conditional recipes
-	modCompile 'com.github.CottonMC:LibCD:b8f768a63d'
-	include 'com.github.CottonMC:LibCD:b8f768a63d'
+	modCompile 'io.github.cottonmc:LibCD:1.3.0+1.14.3'
+	include 'io.github.cottonmc:LibCD:1.3.0+1.14.3'
 
 	// cloth & autoconfig
 	modCompile "cloth-config:ClothConfig:0.2.1.14"
@@ -37,10 +37,6 @@ dependencies {
 
 	// mod menu compat
 	modCompile "io.github.prospector.modmenu:ModMenu:1.5.4-85"
-
-	// jankson for libcd
-	modCompile "blue.endless:jankson:1.1.0"
-	include "blue.endless:jankson:1.1.0"
 }
 
 // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task

--- a/src/main/resources/data/vanilla-hammers/recipes/glowstone_hammer.json.mcmeta
+++ b/src/main/resources/data/vanilla-hammers/recipes/glowstone_hammer.json.mcmeta
@@ -1,3 +1,5 @@
 {
-    "libcd:mod_loaded", "netherthings"
+    "when": [
+        { "libcd:mod_loaded": "netherthings" }
+    ]
 }

--- a/src/main/resources/data/vanilla-hammers/recipes/nether_hammer.json.mcmeta
+++ b/src/main/resources/data/vanilla-hammers/recipes/nether_hammer.json.mcmeta
@@ -1,3 +1,5 @@
 {
-    "libcd:mod_loaded", "netherthings"
+    "when": [
+        { "libcd:mod_loaded": "netherthings" }
+    ]
 }

--- a/src/main/resources/data/vanilla-hammers/recipes/tater_hammer.json.mcmeta
+++ b/src/main/resources/data/vanilla-hammers/recipes/tater_hammer.json.mcmeta
@@ -1,3 +1,5 @@
 {
-    "libcd:mod_loaded", "lil-tater"
+    "when": [
+        { "libcd:mod_loaded": "lil-tater" }
+    ]
 }

--- a/src/main/resources/data/vanilla-hammers/recipes/vibranium_hammer.json.mcmeta
+++ b/src/main/resources/data/vanilla-hammers/recipes/vibranium_hammer.json.mcmeta
@@ -1,3 +1,5 @@
 {
-    "libcd:mod_loaded", "netherthings"
+    "when": [
+        { "libcd:mod_loaded": "netherthings" }
+    ]
 }


### PR DESCRIPTION
- pull LibCD from cotton maven instead of jitpack
- update to new LibCD version for 1.14.3 compat
- update to new format for conditional recipes (along with fixing conditional recipes)
- add `classes/` to gitignore