### PR TITLE
Fixes issue #23

### DIFF
--- a/src/main/java/com/github/draylar/vh/api/HammerItem.java
+++ b/src/main/java/com/github/draylar/vh/api/HammerItem.java
@@ -38,11 +38,6 @@ public class HammerItem extends PickaxeItem
     }
 
     @Override
-    public boolean isEffectiveOn(BlockState state) {
-        return Items.DIAMOND_PICKAXE.isEffectiveOn(state);
-    }
-
-    @Override
     public boolean canMine(BlockState state, World world, BlockPos blockPos, PlayerEntity player) {
         if (VanillaHammers.CONFIG.breakSingleBlockWhenSneaking && player.isSneaking()) {
             return true;


### PR DESCRIPTION
All hammers had diamond level breaking capabilities.
Removing the overridden method isEffectiveOn fixed the problem.

After removing the method, I tested all hammers mining level to see if it is the level of the same material they are composed of.