### PR TITLE
fix NumberFormatExceptions coming from Vanilla Hammers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 	maven { url = 'http://maven.sargunv.s3-website-us-west-2.amazonaws.com/' }
 	maven { url = 'http://server.bbkr.space:8081/artifactory/libs-release' }
 	maven { url = 'https://jitpack.io' }
+	maven { url "https://maven.swordglowsblue.com" }
 
 	jcenter()
 }
@@ -30,8 +31,8 @@ dependencies {
 	modApi "net.fabricmc.fabric-api:fabric-api:0.3.0+build.207"
 
 	// LibCD for conditional recipes
-	modApi 'io.github.cottonmc:LibCD:1.3.1+1.14.4'
-	include 'io.github.cottonmc:LibCD:1.3.1+1.14.4'
+	modApi 'io.github.cottonmc:LibCD:1.6.3+1.14.4'
+	include 'io.github.cottonmc:LibCD:1.6.3+1.14.4'
 
 	// auto config
 	modApi "me.sargunvohra.mcmods:auto-config:1.2.0+mc1.14.4"
@@ -42,7 +43,8 @@ dependencies {
 	include 'me.shedaniel.cloth:config-2:0.5.2'
 
 	// DynaGear for hammers in more materials
-	modApi "io.github.cottonmc:DynaGear:1.2.0+1.14.3"
+	modApi ("io.github.cottonmc:DynaGear:1.3.3+1.14.4") { transitive = false }
+	modApi "artificemc:artifice:0.3.4"
 }
 
 // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task

--- a/src/main/java/com/github/draylar/vh/compat/HammerConfiguredMaterial.java
+++ b/src/main/java/com/github/draylar/vh/compat/HammerConfiguredMaterial.java
@@ -8,7 +8,7 @@ import net.minecraft.sound.SoundEvent;
 
 public class HammerConfiguredMaterial extends ConfiguredMaterial {
 	public HammerConfiguredMaterial(ConfiguredMaterial mat) {
-		this(mat.getName(), Integer.toString(mat.getColor()), mat.getMaterialId(), mat.getBlockMaterialId(), mat.asTool().getEnchantability(),
+		this(mat.getName(), mat.getColorString(), mat.getMaterialId(), mat.getBlockMaterialId(), mat.asTool().getEnchantability(),
 				mat.asTool().getDurability(), mat.asTool().getMiningLevel(), mat.asTool().getMiningSpeed(), mat.asTool().getAttackDamage(),
 				mat.asArmor().getDurability(EquipmentSlot.FEET)/13, getProtAmounts(mat), mat.asArmor().getToughness(), mat.asArmor().getEquipSound());
 	}


### PR DESCRIPTION
This fixes some `NumberFormatException`s on Vanilla Hammers' side. There's still a couple more on DynaGear's side but I'm about to fix those too. These changes should be mirrored in Vanilla Excavators.