### PR TITLE
1.6.3 fix for #36 and #37. Changed Fabric API to build 246. Fixed imp…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 archivesBaseName = "vanilla-hammers"
-version = "1.6.3"
+version = "1.6.3_patch"
 
 minecraft {
 }
@@ -27,7 +27,7 @@ dependencies {
 	minecraft "com.mojang:minecraft:1.14.4"
 	mappings "net.fabricmc:yarn:1.14.4+build.5"
 	modApi "net.fabricmc:fabric-loader:0.4.8+build.159"
-	modApi "net.fabricmc.fabric-api:fabric-api:0.3.0+build.207"
+	modApi "net.fabricmc.fabric-api:fabric-api:0.4.2+build.246-1.14"
 
 	// LibCD for conditional recipes
 	modApi 'io.github.cottonmc:LibCD:1.3.1+1.14.4'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Feb 13 19:34:55 CST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,0 @@
-#Thu Feb 13 19:34:55 CST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/github/draylar/vh/VanillaHammers.java
+++ b/src/main/java/com/github/draylar/vh/VanillaHammers.java
@@ -5,7 +5,7 @@ import com.github.draylar.vh.common.HammerRegistry;
 import me.sargunvohra.mcmods.autoconfig1.AutoConfig;
 import me.sargunvohra.mcmods.autoconfig1.serializer.GsonConfigSerializer;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.impl.registry.FuelRegistryImpl;
+import net.fabricmc.fabric.impl.content.registry.FuelRegistryImpl;
 
 public class VanillaHammers implements ModInitializer
 {


### PR DESCRIPTION
1.6.3 fix for #36 and #37. Changed Fabric API to build 246. Fixed import for FuelRegistry and changed the release version name to 1.6.3_patch. Commits that come after have not been touched.

version bump

(cherry picked from commit f5e33e31ff838c0aa0caa6f982117e63a404488c)